### PR TITLE
Add support for removing variable name comments

### DIFF
--- a/g3po/g3po.py
+++ b/g3po/g3po.py
@@ -454,8 +454,10 @@ def sanitize_variable_name(name):
     name: str, variable name"""
     if not name:
         return name
-    # strip out any characters that aren't letters, numbers, or underscores
-    name = re.sub(r'[^a-zA-Z0-9_]', '', name)
+    # strip out any characters that aren't letters, numbers, spaces, or underscores
+    name = re.sub(r'[^a-zA-Z0-9_ ]', '', name)
+    # take the first "word", in case ChatGPT added extra text behind the new variable name
+    name = list(filter(lambda x: len(x) > 0, name.split(" ")))[0]
     # if the first character is a number, prepend an underscore
     if name[0].isdigit():
         name = 'x' + name


### PR DESCRIPTION
This merge request solves #9. Tested it locally for a while and it seems to work, if anyone can think of any better ways to solve these issues please let me know

In the response
```
- `uVar1` -> `current_element`: represents the current element being compared in the insertion sort
- `iVar2` -> `index`: represents the index of the current element being compared in the insertion sort
- `local_3c` -> `i`: represents the loop counter for the insertion sort
- `local_38` -> `previous_index`: represents the index of the previous element being compared in the insertion sort
- `local_34` -> `j`: represents the loop counter for printing the sorted array
```

it correctly finds

```
uVar1 -> current_element
iVar2 -> index
local_3c -> i
local_38 -> previous_index
local_34 -> j
```

